### PR TITLE
[unzipper] Add type for unzipper.Open.buffer

### DIFF
--- a/types/unzipper/index.d.ts
+++ b/types/unzipper/index.d.ts
@@ -1,4 +1,4 @@
-// Type definitions for unzipper 0.8
+// Type definitions for unzipper 0.9
 // Project: https://github.com/ZJONSSON/node-unzipper#readme
 // Definitions by: s73obrien <https://github.com/s73obrien>
 //                 Nate <https://github.com/natemara>
@@ -57,6 +57,7 @@ export function unzip(
 ): Entry;
 
 export namespace Open {
+    function buffer(data: Buffer): Promise<CentralDirectory>;
     function file(filename: string): Promise<CentralDirectory>;
     function url(
         request: ClientRequest,

--- a/types/unzipper/unzipper-tests.ts
+++ b/types/unzipper/unzipper-tests.ts
@@ -41,3 +41,4 @@ createReadStream("http://example.org/path/to/archive.zip")
 const dir1: Promise<CentralDirectory> = Open.file("Z:\\path\\to\\archive.zip");
 const dir2: Promise<CentralDirectory> = Open.url(get("url/to/archive.zip"), {});
 const dir3: Promise<CentralDirectory> = Open.s3("any", "any");
+const dir4: Promise<CentralDirectory> = Open.buffer(Buffer.from('ZIPDATA'));


### PR DESCRIPTION
A new `Open` method was added, `buffer`.  This updates the types to reflect that change.